### PR TITLE
refactor: log differences instead of key

### DIFF
--- a/src/lib/handlers/CommandRegistryHandler.ts
+++ b/src/lib/handlers/CommandRegistryHandler.ts
@@ -16,7 +16,7 @@ import {
 } from "discord.js";
 import { bold } from "colorette";
 import _ from "lodash";
-import type { Differences } from "../types.js";
+import type { DifferenceData, Differences } from "../types.js";
 import type { IgloClient } from "../Client.js";
 import { InteractionHandlerError, Command } from "../index.js";
 
@@ -170,47 +170,70 @@ export class CommandRegistry {
 		return differences;
 	}
 
-	private optionsAreDifferent(discord: ApplicationCommandOption[], command: ApplicationCommandOption[]): string | null {
-		// Expected options but received no options
-		if (!discord.length && command.length) return "amount";
-		// Expected no options but received options
-		if (discord.length && !command.length) return "amount";
+	private optionsAreDifferent(discord: ApplicationCommandOption[], command: ApplicationCommandOption[]): Differences {
+		const differences: Differences = [];
+
+		// Check Options length
+		if (command.length !== discord.length) differences.push({ key: "options", expected: command.length, received: discord.length });
 
 		// Check to see if commands here include options which aren't at Discord
-		if (command.some((opt) => !discord.find((o) => o.name === opt.name))) return "data-notEqual";
+		const missing = command.filter((opt) => !discord.find((o) => o.name === opt.name));
+		differences.push(...missing.map<DifferenceData>((opt) => ({ key: `option[${opt.name}]`, expected: "object", received: "undefined" })));
 		// Check to see if commands at Discord include options which aren't here
-		if (discord.some((opt) => !command.find((o) => o.name === opt.name))) return "data-notEqual";
+		const existing = discord.filter((opt) => !command.find((o) => o.name === opt.name));
+		differences.push(...existing.map<DifferenceData>((opt) => ({ key: `option[${opt.name}]`, expected: "undefined", received: "object" })));
 
 		// Map over all options to see if they are the same
+		let index = 0;
 		for (const option of command) {
 			const existingOption = discord.find((opt) => opt.name === option.name);
-			const optionsRes = this.isOptionDifferent(existingOption, option);
-			if (optionsRes) return optionsRes;
+			if (!existingOption) continue; // Ignore missing options, already addressed above.
+
+			const optionsRes = this.isOptionDifferent(existingOption, option, index);
+			if (optionsRes) differences.push(...optionsRes);
+
+			index++;
 		}
 
-		return null;
+		return differences;
 	}
 
-	private isOptionDifferent(discord: ApplicationCommandOption | undefined, command: ApplicationCommandOption): string | null {
-		// Expected DiscordOption but received undefined
-		if (!discord) return "undefined";
+	private isOptionDifferent(discord: ApplicationCommandOption, command: ApplicationCommandOption, index: number): Differences {
+		const differences: Differences = [];
+		const optionIndex = `option[${index}]`;
 
-		// check the name localizations
-		if (!_.isEqual(discord.nameLocalizations, command.nameLocalizations ?? null)) return "nameLocalizations";
-		// check the description localizations
-		if (!_.isEqual(discord.descriptionLocalizations, command.descriptionLocalizations ?? null)) return "descriptionLocalizations";
-		// check the description
-		if (discord.description !== command.description) return "description";
+		// Check NameLocalizations
+		differences.push(
+			...this.checkLocalization(discord.nameLocalizations ?? {}, command.nameLocalizations ?? {}, `${optionIndex}.nameLocalizations`)
+		);
+		// Check NameLocalizations
+		differences.push(
+			...this.checkLocalization(
+				discord.descriptionLocalizations ?? {},
+				command.descriptionLocalizations ?? {},
+				`${optionIndex}.descriptionLocalizations`
+			)
+		);
+		// Check description
+		if (discord.description !== command.description)
+			differences.push({ key: `${optionIndex}.description`, expected: command.description, received: discord.description });
 
 		// Check the type
-		if (discord.type !== command.type) return "type";
+		if (discord.type !== command.type)
+			differences.push({
+				key: `${optionIndex}.type`,
+				expected: ApplicationCommandOptionType[command.type],
+				received: ApplicationCommandOptionType[discord.type]
+			});
 		// check if autocomplete is different
-		if ((discord.autocomplete ?? false) !== (command.autocomplete ?? false)) return "autocomplete";
+		if ((discord.autocomplete ?? false) !== (command.autocomplete ?? false))
+			differences.push({ key: `${optionIndex}.autocomplete`, expected: command.autocomplete, received: discord.autocomplete });
 
 		// check if required
 		if ("required" in discord) {
 			const cmd = command as typeof discord;
-			if ((discord.required ?? false) !== (cmd.required ?? false)) return "required";
+			if ((discord.required ?? false) !== (cmd.required ?? false))
+				differences.push({ key: `${optionIndex}.required`, expected: cmd.required, received: discord.required });
 		}
 
 		switch (discord.type) {
@@ -224,15 +247,13 @@ export class CommandRegistry {
 				{
 					const cmd = command as ApplicationCommandStringOption | ApplicationCommandAutocompleteStringOption;
 					const disc = discord as ApplicationCommandStringOption | ApplicationCommandAutocompleteStringOption;
-					if (!_.isEqual(disc.maxLength, cmd.maxLength)) return "maxLength";
-					if (!_.isEqual(disc.minLength, cmd.minLength)) return "minLength";
+					if (!_.isEqual(disc.maxLength, cmd.maxLength))
+						differences.push({ key: `${optionIndex}.maxLength`, expected: cmd.maxLength, received: disc.maxLength });
+					if (!_.isEqual(disc.minLength, cmd.minLength))
+						differences.push({ key: `${optionIndex}.minLength`, expected: cmd.minLength, received: disc.minLength });
 
-					// Expected choices but got undefined (and reversed)
 					// @ts-ignore Discord data returns undefined if no choices are passed, we should do the same with local data
 					cmd.choices ??= undefined;
-					if ("choices" in disc && !("choices" in cmd)) return "choices";
-					if (!("choices" in disc) && "choices" in cmd) return "choices";
-
 					if ("choices" in disc && "choices" in cmd) {
 						const discChoices = disc.choices ?? [];
 						const cmdChoices = cmd.choices ?? [];
@@ -249,8 +270,10 @@ export class CommandRegistry {
 						};
 
 						// one of the items has more than expected
-						if (discChoices.length !== cmdChoices.length) return "choices-amount";
-						if (cmdChoices.some(someChoice)) return "choices-notEqual";
+						if (discChoices.length !== cmdChoices.length)
+							differences.push({ key: `${optionIndex}.choices.length`, expected: cmdChoices.length, received: discChoices.length });
+						if (cmdChoices.some(someChoice))
+							differences.push({ key: `${optionIndex}.choices`, expected: cmdChoices, received: discChoices });
 					}
 				}
 				break;
@@ -259,8 +282,8 @@ export class CommandRegistry {
 					const disc = discord as ApplicationCommandChannelOption;
 					const cmd = command as ApplicationCommandChannelOption;
 
-					if (disc.channelTypes?.length !== cmd.channelTypes?.length) return "channel-amount";
-					if (!_.isEqual(disc.channelTypes, cmd.channelTypes)) return "channel-channelTypes";
+					if (disc.channelTypes?.length !== cmd.channelTypes?.length || !_.isEqual(cmd.channelTypes, disc.channelTypes))
+						differences.push({ key: `${optionIndex}.channelTypes`, expected: cmd.channelTypes, received: disc.channelTypes });
 				}
 				break;
 			case ApplicationCommandOptionType.Integer:
@@ -268,18 +291,20 @@ export class CommandRegistry {
 				{
 					const cmd = command as ApplicationCommandNumericOption | ApplicationCommandAutocompleteNumericOption;
 					const disc = discord as ApplicationCommandNumericOption | ApplicationCommandAutocompleteNumericOption;
-					if (!_.isEqual(disc.maxValue, cmd.maxValue)) return "int-maxValue";
-					if (!_.isEqual(disc.minValue, cmd.minValue)) return "int-minValue";
+					if (!_.isEqual(disc.maxValue, cmd.maxValue))
+						differences.push({ key: `${optionIndex}.maxValue`, expected: cmd.maxValue, received: disc.maxValue });
+					if (!_.isEqual(disc.minValue, cmd.minValue))
+						differences.push({ key: `${optionIndex}.minValue`, expected: cmd.minValue, received: disc.minValue });
 				}
 				break;
 			default:
 				break;
 		}
 
-		return null;
+		return differences;
 	}
 
-	private checkLocalization(discord: Record<string, string | null>, command: Record<string, string>, objectKey: string): Differences {
+	private checkLocalization(discord: Record<string, string | null>, command: Record<string, string | null>, objectKey: string): Differences {
 		const differences: Differences = [];
 		Object.keys(command).forEach((key) => {
 			const received = discord[key];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,3 +19,11 @@ export interface IgloClientOptions {
 		interactions: string;
 	};
 }
+
+export interface DifferenceData {
+	received: any;
+	expected: any;
+	key: string;
+}
+
+export type Differences = DifferenceData[];


### PR DESCRIPTION
### Please describe the changes this PR makes:
- Logs an array of differences instead of returning the key of a different object

<!--
### Linked Issues:
Mention an issue here (example: #1)
-->

---

<!--
### To do list:
- [ ] list item 1
  - [ ] list item 2
    - [ ] list item 3
-->
